### PR TITLE
Added settings options for inline editing and remembering type

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,11 +1,37 @@
 import {Plugin} from 'obsidian';
 import CreationModal from "./CreationModal";
+import {MatrixSettingTab} from "./settings";
+
+interface MatrixPluginSettings {
+	rememberMatrixType: boolean;
+	inline: boolean;
+	lastUsedMatrix: string;
+}
+
+const DEFAULT_SETTINGS: Partial<MatrixPluginSettings> = {
+	rememberMatrixType: true,
+	inline: false,
+	lastUsedMatrix: "",
+  };
 
 export default class MyPlugin extends Plugin {
+	settings: MatrixPluginSettings;
 
 	async onload() {
 		this.addRibbonIcon("pane-layout", "Obsidian Matrix", () => {
-			new CreationModal(this.app).open()
+			new CreationModal(this.app, this).open()
 		});
+
+		await this.loadSettings();
+
+		this.addSettingTab(new MatrixSettingTab(this.app, this));
+	}
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
 	}
 }

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,41 @@
+import MyPlugin from "./main";
+import { App, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
+
+export class MatrixSettingTab extends PluginSettingTab {
+  plugin: MyPlugin;
+
+  constructor(app: App, plugin: MyPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("Remember previous matrix type")
+      .setDesc("After choosing a matrix type and clicking \"Create\", the type will be selected by default the next time you open the matrix creation window.")
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(this.plugin.settings.rememberMatrixType)
+          .onChange(async (value: boolean) => {
+            this.plugin.settings.rememberMatrixType = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Put matrix command on one line")
+      .setDesc("Rather than inserting a newline after each row of the matrix, all text will be placed on one line. This will allow the matrix to immediately work between inline (single) $-signs, as well as multiline $$-signs.")
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(this.plugin.settings.inline)
+          .onChange(async (value: boolean) => {
+            this.plugin.settings.inline = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}


### PR DESCRIPTION
Hi! I use your extension frequently for my math notes, and I wanted to fix a few things that have been bugging me (not flaws with the extension, just settings that help me in my usage, and that others might benefit from).

Added settings panel, added two features that would be very useful for how I use the extension and I think will be useful to others as well:
When the corresponding option is checked in settings:
inline: matrix text will not include newline characters (option disabled by default as it makes output less readable)
remember type: the last used matrix type will be selected in the dropdown on future uses of the GUI (option enabled by default as it saves time for repeated uses)