### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-
+{
 	"id": "obsidian-matrix",
 	"name": "Obsidian matrix",
 	"version": "1.2.0",


### PR DESCRIPTION
`manifest.json`: Looks like the opening '{' got accidentally deleted in the last commit, and it makes the plugin break (error "failed to load manifest" in the community browser and silent fail when installed locally). This should fix it.