### PR TITLE
Add hotkey to open GUI and setting to remember matrix dimensions

### DIFF
--- a/CreationModal.ts
+++ b/CreationModal.ts
@@ -41,7 +41,12 @@ export default class CreationModal extends Modal {
 			}
 		});
 		new Setting(this.settingsDiv).setName("Matrix width").addSlider((slider) => {
-			slider.setValue(2);
+			if (this.parentPlugin.settings.rememberMatrixDimensions) {
+				slider.setValue(this.parentPlugin.settings.prevX == null ? 2 : this.parentPlugin.settings.prevX);
+				this.matrixWidth = this.parentPlugin.settings.prevX == null ? 2 : this.parentPlugin.settings.prevX;
+			} else {
+				slider.setValue(2);
+			}
 			slider.setLimits(1, 10, 1);
 			slider.showTooltip();
 			slider.setDynamicTooltip();
@@ -51,7 +56,12 @@ export default class CreationModal extends Modal {
 			});
 		});
 		new Setting(this.settingsDiv).setName("Matrix height").addSlider((slider) => {
-			slider.setValue(2);
+			if (this.parentPlugin.settings.rememberMatrixDimensions) {
+				slider.setValue(this.parentPlugin.settings.prevY == null ? 2 : this.parentPlugin.settings.prevY);
+				this.matrixHeight = this.parentPlugin.settings.prevY == null ? 2 : this.parentPlugin.settings.prevY;
+			} else {
+				slider.setValue(2);
+			}
 			slider.setLimits(1, 10, 1);
 			slider.showTooltip();
 			slider.setDynamicTooltip();
@@ -66,6 +76,11 @@ export default class CreationModal extends Modal {
 			button.onClick(() => {
 				if (this.parentPlugin.settings.rememberMatrixType) {
 					this.parentPlugin.settings.lastUsedMatrix = this.selectedMatrix;
+					this.parentPlugin.saveSettings();
+				}
+				if (this.parentPlugin.settings.rememberMatrixDimensions) {
+					this.parentPlugin.settings.prevX = this.matrixWidth;
+					this.parentPlugin.settings.prevY = this.matrixHeight;
 					this.parentPlugin.saveSettings();
 				}
 

--- a/main.ts
+++ b/main.ts
@@ -3,15 +3,21 @@ import CreationModal from "./CreationModal";
 import {MatrixSettingTab} from "./settings";
 
 interface MatrixPluginSettings {
-	rememberMatrixType: boolean;
-	inline: boolean;
-	lastUsedMatrix: string;
+	rememberMatrixType: boolean; // Whether to save matrix type
+	rememberMatrixDimensions: boolean; // Whether to save matrix dimensions
+	inline: boolean; // Whether to put all generated text on one line
+	lastUsedMatrix: string; // Previously-used type of matrix
+	prevX: number | null; // Previously-used matrix X dimension
+	prevY: number | null; // Previously-used matrix Y dimension
 }
 
 const DEFAULT_SETTINGS: Partial<MatrixPluginSettings> = {
 	rememberMatrixType: true,
+	rememberMatrixDimensions: true,
 	inline: false,
 	lastUsedMatrix: "",
+	prevX: null,
+	prevY: null,
   };
 
 export default class MyPlugin extends Plugin {
@@ -20,6 +26,15 @@ export default class MyPlugin extends Plugin {
 	async onload() {
 		this.addRibbonIcon("pane-layout", "Obsidian Matrix", () => {
 			new CreationModal(this.app, this).open()
+		});
+
+		this.addCommand({
+			id: "obsidian-matrix-shortcut",
+			name: "Open Obsidian Matrix menu",
+			hotkeys: [],
+			callback: () => {
+				new CreationModal(this.app, this).open()
+			},
 		});
 
 		await this.loadSettings();

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-
+{
 	"id": "obsidian-matrix",
 	"name": "Obsidian matrix",
 	"version": "1.2.0",

--- a/settings.ts
+++ b/settings.ts
@@ -27,6 +27,18 @@ export class MatrixSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Remember previous matrix dimensions")
+      .setDesc("After entering a matrix and clicking \"Create\", the dimensions will be selected by default the next time you open the matrix creation window.")
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(this.plugin.settings.rememberMatrixDimensions)
+          .onChange(async (value: boolean) => {
+            this.plugin.settings.rememberMatrixDimensions = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
       .setName("Put matrix command on one line")
       .setDesc("Rather than inserting a newline after each row of the matrix, all text will be placed on one line. This will allow the matrix to immediately work between inline (single) $-signs, as well as multiline $$-signs.")
       .addToggle((toggle: ToggleComponent) =>


### PR DESCRIPTION
Hotkey has no default value, but can be set in the Hotkeys menu (name: "open Obsidian Matrix menu"). Setting to remember matrix dimensions works the same way as the setting to remember matrix type (but saves 2 values instead of 1).